### PR TITLE
Fix dockerfile requirements location

### DIFF
--- a/generators/app/templates/django/mysite/Dockerfile
+++ b/generators/app/templates/django/mysite/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.5
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
-ADD requirements* /code/
+ADD requirements* /code/requirements/
 RUN pip install -r requirements/dev.txt
 ADD . /code/


### PR DESCRIPTION
Fix Issue https://github.com/metakermit/generator-django-rest/issues/1

Here are steps I used to test it manually:

* `yo django-rest` (project created)
* `./scripts/devsetup.sh` (setup finished)
* Change db to sqlite, in `.env` file
`DATABASE_URL=sqlite://db.sqlite`

* `docker-compose up` (runs without errors mentioned here https://github.com/metakermit/generator-django-rest/issues/1 )


p.s. using `postgresql` in docker had some connection issues in my case, that's why I have used `sqlite` to verify requirements file location fix https://github.com/metakermit/generator-django-rest/issues/1 easily.