### PR TITLE
graphql with batteries

### DIFF
--- a/generators/app/templates/django/mysite/mysite/schema.py
+++ b/generators/app/templates/django/mysite/mysite/schema.py
@@ -1,0 +1,38 @@
+from graphene_django import DjangoObjectType
+from graphene_django.filter import DjangoFilterConnectionField
+from graphene_django.rest_framework.mutation import SerializerMutation
+from graphene.relay import Node
+from graphene import ObjectType, Schema
+from rest_framework import serializers
+
+from django.contrib.auth.models import User
+
+
+class UserNode(DjangoObjectType):
+    class Meta:
+        model = User
+        filter_fields = ['username', 'email']
+        interfaces = (Node, )
+
+
+class Query(ObjectType):
+    user = Node.Field(UserNode)
+    all_users = DjangoFilterConnectionField(UserNode)
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'email')
+
+
+class UserMutation(SerializerMutation):
+    class Meta:
+        serializer_class = UserSerializer
+
+
+class Mutation(ObjectType):
+    user = UserMutation.Field()
+
+
+schema = Schema(query=Query, mutation=Mutation)

--- a/generators/app/templates/django/mysite/mysite/settings.py
+++ b/generators/app/templates/django/mysite/mysite/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
     'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
     'rest_framework',
+    'graphene_django',
     'corsheaders',
     'anymail',
     'debug_toolbar',
@@ -215,3 +216,8 @@ CORS_ORIGIN_WHITELIST = (
     '127.0.0.1:8000',
 )
 # CORS_ALLOW_CREDENTIALS = True
+
+GRAPHENE = {
+    # Where your Graphene schema lives
+    'SCHEMA': '<%= project_name %>.schema.schema'
+}

--- a/generators/app/templates/django/mysite/mysite/urls.py
+++ b/generators/app/templates/django/mysite/mysite/urls.py
@@ -19,6 +19,10 @@ from django.contrib import admin
 from django.conf.urls.static import static
 from django.views.generic import RedirectView
 from django.conf import settings
+from graphene_django.views import GraphQLView
+
+from .schema import schema
+
 
 admin.autodiscover()
 
@@ -27,6 +31,7 @@ urlpatterns = [
     # - everything not matched in Django's urlpatterns goes to /
     # - index.html served on /
     # - all /static/... files served on /...
+    path('graphql/', GraphQLView.as_view(graphiql=True, schema=schema)),
 
     # other views still work too
     path('admin/', admin.site.urls),

--- a/generators/app/templates/projectfiles/Pipfile
+++ b/generators/app/templates/projectfiles/Pipfile
@@ -5,6 +5,8 @@ name = "pypi"
 
 [packages]
 Django = "==2.0.4"
+"graphene-django" = "==2.0.0"
+"django-filter" = "==1.1.0"
 "django-backblazeb2-storage" = "*"
 django-environ = "*"
 django-extensions = "*"


### PR DESCRIPTION
Includes a simple user endpoint with filtering and writing enabled. Felt the API creation process isn't straight forward (lots of choices) and wanted to demonstrate an optimal Django selection that could be quickly copied and modified.