### PR TITLE
Yank `pipenv run` from docker since deps are installed at system level.

### DIFF
--- a/generators/app/templates/django/mysite/docker-compose.yml
+++ b/generators/app/templates/django/mysite/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     #env_file: .env
     #command: python manage.py runserver 0.0.0.0:8000
     restart: on-failure
-    command: pipenv run gunicorn <%= project_name %>.wsgi -c <%= project_name %>/gunicorn.conf.py
+    command: gunicorn <%= project_name %>.wsgi -c <%= project_name %>/gunicorn.conf.py
     environment:
       DATABASE_URL: psql://secret:postgres@db/postgres
       REDIS_URL: redis://cache:6379
@@ -27,9 +27,10 @@ services:
   cli:
     image: <%= project_name %>
     #env_file: .env
-    entrypoint: pipenv run python manage.py
+    entrypoint: python manage.py
     environment:
       DATABASE_URL: psql://postgres@db/postgres
+      REDIS_URL: redis://cache:6379
     volumes:
       - .:/code
     links:

--- a/generators/app/templates/django/mysite/requirements.txt
+++ b/generators/app/templates/django/mysite/requirements.txt
@@ -1,1 +1,0 @@
--r requirements/prod.txt

--- a/test/app.js
+++ b/test/app.js
@@ -13,7 +13,7 @@ describe('generator-django-rest:app', function () {
   it('creates files', function () {
     assert.file([
       'manage.py',
-      'requirements.txt'
+      'Pipfile'
     ]);
   });
 });


### PR DESCRIPTION
With docker the dependencies are installed at the system level; don't run commands in pipenv. Otherwise the system will complain that it's not finding dependencies.

+ remove old requirements file
+ add REDIS_URL to cli container